### PR TITLE
A non-existent key should not be created

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Joins (sub-queries) are also supported by providing a map in place of a keyword 
 If a value is a sequence (sequential?) of map, query inside will return a vector of values, just like in Datomic's pull api.
 
 ```clojure
-(pull {:person/name "Joe" :person/childen [{:person/name "Bob"} {:person/name "Alice"}]}
+(pull {:person/name "Joe" :person/children [{:person/name "Bob"} {:person/name "Alice"}]}
       [:person/name {:person/children [:person/name]}])
 
 ;;=> {:person/name "Joe" :person/children [{:person/name "Bod"} {:person/name "Alice"}]}
@@ -76,7 +76,7 @@ If a value is a sequence (sequential?) of map, query inside will return a vector
 You can define attributes (values) not exists but calculated by the value of the map, they are shadow attributes:
 
 ```clojure
-(pull {:person/name "Joe" :person/childen [{:person/name "Bob"} {:person/name "Alice"}]}
+(pull {:person/name "Joe" :person/children [{:person/name "Bob"} {:person/name "Alice"}]}
       [:person/name :person/num-kids]
       {:shadow {:person/num-kids #(-> % :person/children count)}})
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject robertluo/pull "0.2.9"
+(defproject robertluo/pull "0.2.10"
   :description "Trees from tables"
   :min-lein-version "2.7.0"
   :url "http://github.com/robertluo/pull"

--- a/src/juxt/pull/core/impl.clj
+++ b/src/juxt/pull/core/impl.clj
@@ -40,7 +40,7 @@
   [global [k v] q opts]
   (if (all-findable? v)
       {k (mapv #(pull global % q opts) v)}
-      [k (pull global v q opts)]))
+      {k (pull global v q opts)}))
 
 (defn join-prop
   [prop local global opts]
@@ -75,9 +75,10 @@
                    acc)
 
                  (join? prop)
-                 (if (contains? local (ffirst prop))
-                   (conj acc (join-prop prop local global opts))
-                   acc)
+                 (let [joined-prop (join-prop prop local global opts)]
+                   (if (= (ffirst joined-prop) (ffirst prop))
+                     (conj acc joined-prop)
+                     acc))
                  :otherwise acc))
              {}
              query))))

--- a/src/juxt/pull/core/impl.clj
+++ b/src/juxt/pull/core/impl.clj
@@ -75,7 +75,9 @@
                    acc)
 
                  (join? prop)
-                 (conj acc (join-prop prop local global opts))
+                 (if (contains? local (ffirst prop))
+                   (conj acc (join-prop prop local global opts))
+                   acc)
                  :otherwise acc))
              {}
              query))))

--- a/test/juxt/pull/core_test.clj
+++ b/test/juxt/pull/core_test.clj
@@ -65,7 +65,7 @@
 
   (testing "deep shadow attributes"
     (is (= {:tags [{:name "foo"} {:name "bar"}]}
-           (pull {}
+           (pull {:tags {:age 10}}
                  [{:tags [:name]}]
                  {:shadow
                   {:tags

--- a/test/juxt/pull/core_test.clj
+++ b/test/juxt/pull/core_test.clj
@@ -65,7 +65,7 @@
 
   (testing "deep shadow attributes"
     (is (= {:tags [{:name "foo"} {:name "bar"}]}
-           (pull {:tags {:age 10}}
+           (pull {}
                  [{:tags [:name]}]
                  {:shadow
                   {:tags

--- a/test/juxt/pull/core_test.clj
+++ b/test/juxt/pull/core_test.clj
@@ -106,3 +106,16 @@
 (deftest pull-on-nil
   (testing "Pull on nil just returns nil"
     (is (nil? (pull nil [:a])))))
+
+(deftest pull-not-add-nil-key
+  (testing "Pull on map collections should not add nil key"
+    (is (= {:a 1
+            :c [{:type :wuxing :amount 100}
+                {:type :seed :seed {:id "111"}}]}
+           (pull {:a 1
+                  :c [{:type   :wuxing
+                       :amount 100}
+                      {:type :seed
+                       :seed {:id "111"}}]}
+                 [:a {:c [:type :amount
+                          {:seed [:id]}]}])))))


### PR DESCRIPTION
```clojure
(pull {:a 1
       :c [{:type   :wuxing
            :amount 100}
           {:type :seed
            :seed {:id "111"}}]}
      [:a {:c [:type :amount
               {:seed [:id]}]}])
==>
{:a 1,
 :c [{:type   :wuxing
      :amount 100
      nil     nil}
     {:type :seed
      :seed {:id "111"}}]}
```

* `{nil, nil}` 被创建了，在原本的 `{:type :wuxing :amount 100}` 中，它是不存在的，而且也不应该存在，我们额外添加了原本不存在的数据，不合理。
* 当然，影子属性中指定了一个新 key，这是合理的。